### PR TITLE
Calibration Table / HEALPix output fixes 

### DIFF
--- a/SWHT/fileio.py
+++ b/SWHT/fileio.py
@@ -434,9 +434,13 @@ def readACC(fn, fDict, lofarStation, sbs, calTable=None):
 
     # read LOFAR Calibration Table
     if not (calTable is None):
+        antGains = lofarStation.antField.antGains
         if antGains is None: # read the Cal Table only once
             print 'Using CalTable:', calTable
             antGains = lofarConfig.readCalTable(calTable, nants, nchan, npols)
+            lofarStation.antField.antGains = antGains
+        else:
+            print 'Using Cached CalTable:', calTable
     else: antGains = None
 
     # get correlation matrix for subbands selected
@@ -487,11 +491,15 @@ def readXST(fn, fDict, lofarStation, sbs, calTable=None):
     print 'SUBBANDS:', sbs, '(', freqs/1e6, 'MHz)'
     npols = 2
 
-    #read LOFAR Calibration Table
+    # read LOFAR Calibration Table
     if not (calTable is None):
-        if antGains is None: #read the Cal Table only once
+        antGains = lofarStation.antField.antGains
+        if antGains is None: # read the Cal Table only once
             print 'Using CalTable:', calTable
             antGains = lofarConfig.readCalTable(calTable, nants, nchan, npols)
+            lofarStation.antField.antGains = antGains
+        else:
+            print 'Using Cached CalTable:', calTable
     else: antGains = None
 
     # get correlation matrix for subbands selected
@@ -545,11 +553,15 @@ def readKAIRAXST(fn, fDict, lofarStation, sbs, calTable=None, times='0'):
     print 'SUBBANDS:', sbs, '(', freqs/1e6, 'MHz)'
     npols = 2
 
-    #read LOFAR Calibration Table
+    # read LOFAR Calibration Table
     if not (calTable is None):
-        if antGains is None: #read the Cal Table only once
+        antGains = lofarStation.antField.antGains
+        if antGains is None: # read the Cal Table only once
             print 'Using CalTable:', calTable
             antGains = lofarConfig.readCalTable(calTable, nants, nchan, npols)
+            lofarStation.antField.antGains = antGains
+        else:
+            print 'Using Cached CalTable:', calTable
     else: antGains = None
 
     # get correlation matrix for subbands selected

--- a/SWHT/fileio.py
+++ b/SWHT/fileio.py
@@ -216,8 +216,8 @@ def lofarACCSelectSbs(fn, sbs, nchan, nantpol, intTime, antGains=None):
         if antGains is None:
             sbCorrMatrix[sbIdx] = corrMatrix[sb, :, :] # select out a single subband, shape (nantpol, nantpol)
         else: # Apply Gains
-            sbAntGains = antGains[sb][np.newaxis].T
-            sbVisGains = np.conjugate(np.dot(sbAntGains, sbAntGains.T)) # from Tobia, visibility gains are computed as (G . G^T)*
+            sbAntGains = antGains[sb].T
+            sbVisGains = np.dot(sbAntGains, np.conj(sbAntGains.T))
             sbCorrMatrix[sbIdx] = np.multiply(sbVisGains, corrMatrix[sb, :, :]) # select out a single subband, shape (nantpol, nantpol)
 
         # correct the time due to subband stepping
@@ -246,15 +246,15 @@ def lofarXST(fn, sb, nantpol, antGains=None):
     """
     corrMatrix = np.fromfile(fn, dtype='complex').reshape(1, nantpol, nantpol) #read in the correlation matrix
     if antGains is None:
-        sbCorrMatrix = corrMatrix # shape (1, nantpol, nantpol)
+        sbCorrMatrix = corrMatrix[np.newaxis, ...] # shape (1, 1, nantpol, nantpol)
     else: # Apply Gains
-        sbAntGains = antGains[sb][np.newaxis].T
-        sbVisGains = np.conjugate(np.dot(sbAntGains, sbAntGains.T)) # from Tobia, visibility gains are computed as (G . G^T)*
+        sbAntGains = antGains[sb].T
+        sbVisGains = np.dot(sbAntGains, np.conj(sbAntGains.T))
         sbCorrMatrix = np.multiply(sbVisGains, corrMatrix) # shape (1, nantpol, nantpol)
+        sbCorrMatrix = np.reshape(sbCorrMatrix, (1, 1, nantpol, nantpol)) # add integration axis
     tDeltas = [datetime.timedelta(0, 0)] # no time offset
 
     tDeltas = np.array(tDeltas)[np.newaxis] # put in the shape [Nsubbands, Nints]
-    sbCorrMatrix = np.reshape(sbCorrMatrix, (1, 1, nantpol, nantpol)) # add integration axis
 
     print 'CORRELATION MATRIX SHAPE', corrMatrix.shape
     print 'REDUCED CORRELATION MATRIX SHAPE', sbCorrMatrix.shape
@@ -302,8 +302,8 @@ def lofarKAIRAXST(fn, sb, nantpol, intTime, antGains=None, times='0'):
 
     tDeltas = [] # integration timestamp deltas from the end of file
     if antGains is not None: # Apply Gains
-        sbAntGains = antGains[sb][np.newaxis].T
-        sbVisGains = np.conjugate(np.dot(sbAntGains, sbAntGains.T)) # from Tobia, visibility gains are computed as (G . G^T)*
+        sbAntGains = antGains[sb].T
+        sbVisGains = np.dot(sbAntGains, np.conj(sbAntGains.T))
         reducedCorrMatrix = sbVisGains * reducedCorrMatrix # Apply gains
     for tIdx, tid in enumerate(tids):
         #if antGains is not None: # Apply Gains

--- a/SWHT/lofarConfig.py
+++ b/SWHT/lofarConfig.py
@@ -105,6 +105,7 @@ class antennaField():
         self.antpos = {} #ITRF positions relative to station ITRF in self.location
         self.localAntPos = {} #local horizon plane positions obtained from applying station rotation matrix to self.antpos
         self.location = {} #station ITRF position
+        self.antGains = None
         fh=open(fn)
         lines = []
         lines = fh.read().split('\n')

--- a/scripts/ftVisibilities.py
+++ b/scripts/ftVisibilities.py
@@ -113,7 +113,7 @@ if __name__ == '__main__':
             else:
                 sbs = fDict['sb']
 
-            vis, uvw, freqs, obsInfo = SWHT.fileio.readXST(visFn, fDict, lofarStation, sbs)
+            vis, uvw, freqs, obsInfo = SWHT.fileio.readXST(visFn, fDict, lofarStation, sbs, calTable=opts.calfile)
             [obsLat, obsLong, LSTangle] = obsInfo
 
             # add visibilities to previously processed files

--- a/scripts/plotUVW.py
+++ b/scripts/plotUVW.py
@@ -95,7 +95,7 @@ if __name__ == '__main__':
             else:
                 sbs = fDict['sb']
 
-            vis, uvw, freqs, obsInfo = SWHT.fileio.readXST(visFn, fDict, lofarStation, sbs)
+            vis, uvw, freqs, obsInfo = SWHT.fileio.readXST(visFn, fDict, lofarStation, sbs, calTable=opts.calfile)
             [obsLat, obsLong, LSTangle] = obsInfo
 
             # add visibilities to previously processed files

--- a/scripts/swhtVisibilities.py
+++ b/scripts/swhtVisibilities.py
@@ -222,7 +222,10 @@ if __name__ == '__main__':
     ## Imaging
     ####################
     if opts.of is None:
-        if opts.imageMode.startswith('heal'): outFn = 'tempImage.hpx'
+        if opts.imageMode.startswith('heal'): 
+            outFn = 'tempImage.hpx'
+            if os.path.exists(outFn):
+                os.remove(outFn)
         else: outFn = 'tempImage.pkl'
     else: outFn = opts.of
 

--- a/scripts/swhtVisibilities.py
+++ b/scripts/swhtVisibilities.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
             else:
                 sbs = fDict['sb']
 
-            vis, uvw, freqs, obsInfo = SWHT.fileio.readXST(visFn, fDict, lofarStation, sbs)
+            vis, uvw, freqs, obsInfo = SWHT.fileio.readXST(visFn, fDict, lofarStation, sbs, calTable=opts.calfile)
             [obsLat, obsLong, LSTangle] = obsInfo
 
             # add visibilities to previously processed files


### PR DESCRIPTION
This pull request

- Implements a fix for the HEALPix output method in the default sample scripts. Where previously the script would crash with a file already exists error if a tempImage.hpx file exists, it should not be removed prior to writing the new image to disk

- Slightly reworks the calibration cache, where previously this was a variable that wasn't available to the scope of the read functions, we now cache the antenna gains in antennaField objects.

- Starts applying calibration to XST files in the default scripts, previously this flag was ignored.

- Reworks some of the calibration code following the above changes showing issues with it. Notably we change the gain weight being generated by (G . G.T)* to (G . G.T*) and some minor axis changes. This change has been tested with ACC and XST data from IE613, but has not been tested with KAIRA data as I have not got access to any. The changes of before/after calibration can be compared for an all sky observations here https://imgur.com/a/PWL9bmW